### PR TITLE
chore: optimize target switching performance

### DIFF
--- a/src/gui/workspace/Blockly/index.tsx
+++ b/src/gui/workspace/Blockly/index.tsx
@@ -15,6 +15,7 @@ import { getBlocklyMenuOptions, getBlocklyMenuEvent } from '../../../lib/Blockly
 
 const BlocklyWorkspace = ({ vm, targetId }: { vm: IVM; targetId: string }): React.ReactNode => {
     const workspaceDiv = useRef<HTMLDivElement>(null);
+    const initialTargetId = useRef(targetId);
 
     useContextMenu(AllContextMenu.BLOCKLY, closeMenu => {
         const options = getBlocklyMenuOptions();
@@ -57,16 +58,20 @@ const BlocklyWorkspace = ({ vm, targetId }: { vm: IVM; targetId: string }): Reac
     useEffect(() => {
         if (!workspaceDiv.current) return;
 
-        if (vm.runtime.editingTargetID !== targetId) {
-            vm.runtime.switchTarget(targetId);
-        }
-
+        if (vm.runtime.editingTargetID !== initialTargetId.current)
+            vm.runtime.switchTarget(initialTargetId.current);
         void vm.runtime.blocks.createWorkspace(workspaceDiv.current, false);
 
         return () => {
             vm.runtime.blocks.dispose();
         };
-    }, [vm, vm.on, targetId]);
+    }, [vm, vm.on]);
+
+    useEffect(() => {
+        if (!workspaceDiv.current || targetId === initialTargetId.current) return;
+        if (vm.runtime.editingTargetID !== targetId) vm.runtime.switchTarget(targetId);
+        void vm.runtime.blocks.createWorkspace(workspaceDiv.current, false);
+    }, [vm, targetId]);
 
     return (
         <div className={styles.root}>

--- a/src/gui/workspace/Blockly/index.tsx
+++ b/src/gui/workspace/Blockly/index.tsx
@@ -15,7 +15,7 @@ import { getBlocklyMenuOptions, getBlocklyMenuEvent } from '../../../lib/Blockly
 
 const BlocklyWorkspace = ({ vm, targetId }: { vm: IVM; targetId: string }): React.ReactNode => {
     const workspaceDiv = useRef<HTMLDivElement>(null);
-    const initialTargetId = useRef(targetId);
+    const disposeTimer = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     useContextMenu(AllContextMenu.BLOCKLY, closeMenu => {
         const options = getBlocklyMenuOptions();
@@ -58,19 +58,22 @@ const BlocklyWorkspace = ({ vm, targetId }: { vm: IVM; targetId: string }): Reac
     useEffect(() => {
         if (!workspaceDiv.current) return;
 
-        if (vm.runtime.editingTargetID !== initialTargetId.current)
-            vm.runtime.switchTarget(initialTargetId.current);
+        if (disposeTimer.current) {
+            clearTimeout(disposeTimer.current);
+            disposeTimer.current = null;
+        }
+
+        if (vm.runtime.editingTargetID !== targetId) vm.runtime.switchTarget(targetId);
         void vm.runtime.blocks.createWorkspace(workspaceDiv.current, false);
 
         return () => {
-            vm.runtime.blocks.dispose();
+            // React 会在下一个 targetId effect 之前运行清理
+            // 延迟释放以便目标切换时保持现有的 Blockly 工作区活着
+            disposeTimer.current = setTimeout(() => {
+                disposeTimer.current = null;
+                vm.runtime.blocks.dispose();
+            }, 0);
         };
-    }, [vm, vm.on]);
-
-    useEffect(() => {
-        if (!workspaceDiv.current || targetId === initialTargetId.current) return;
-        if (vm.runtime.editingTargetID !== targetId) vm.runtime.switchTarget(targetId);
-        void vm.runtime.blocks.createWorkspace(workspaceDiv.current, false);
     }, [vm, targetId]);
 
     return (


### PR DESCRIPTION
# 问题
工作区切换总会卡个几百毫秒，火焰图显示它会重建整个工作区。
<img width="907" height="736" alt="image" src="https://github.com/user-attachments/assets/dae7a3f1-4725-41d1-81bc-308afc625287" />

# 原因
`useEffect`生命周期的问题，
``` ts
return () => {
    vm.runtime.blocks.dispose();
    ...
}
```
总会被调用，导致每次都是重建了工作区。

# 措施
现在加了个计时器暂缓，让它不会立马就重建，保存了工作区，让它“缓存命中”