### PR TITLE
feat(renderer): WebGL/WebGPU stage renderer + Stage panel

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -3,3 +3,4 @@ dist
 dist-ssr
 pnpm-lock.yaml
 *.local
+*.svg

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
         "@types/semver": "^7.8.0",
         "@types/wicg-file-system-access": "^2023.10.7",
         "@vitejs/plugin-react": "^6.0.5",
+        "@webgpu/types": "^0.1.72",
         "babel-plugin-react-compiler": "^1.0.0",
         "eslint": "^10.9.1",
         "eslint-config-prettier": "^10.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,6 +105,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^6.0.5
         version: 6.1.0(@rolldown/plugin-babel@0.2.3(@babel/core@8.0.1)(@babel/runtime@7.29.7)(rolldown@1.2.5)(vite@8.2.2(@types/node@26.3.0)(sass@1.103.1)))(babel-plugin-react-compiler@1.0.0)(vite@8.2.2(@types/node@26.3.0)(sass@1.103.1))
+      '@webgpu/types':
+        specifier: ^0.1.72
+        version: 0.1.72
       babel-plugin-react-compiler:
         specifier: ^1.0.0
         version: 1.0.0
@@ -890,6 +893,9 @@ packages:
 
   '@vitest/utils@4.1.11':
     resolution: {integrity: sha512-zTCVGpyFsGWBhllOyKlTw/vnr6D9qxsfSDyfbyZmTyjHw5N/VuvzHpHoQjm2ZJzn4RJgx5w4r7V0er69CmLgPQ==}
+
+  '@webgpu/types@0.1.72':
+    resolution: {integrity: sha512-0cF7RFM2edNoiIS1ODJp0/Gzv4/xSXhwoR0YCza+OWpJWtn4wmo9DvK91aLlH9+uUnwIriP7ZiC3WitmyhuzBw==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -2918,6 +2924,8 @@ snapshots:
       '@vitest/pretty-format': 4.1.11
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.1
+
+  '@webgpu/types@0.1.72': {}
 
   acorn-jsx@5.3.2(acorn@8.18.0):
     dependencies:

--- a/src/assets/stage.svg
+++ b/src/assets/stage.svg
@@ -1,0 +1,5 @@
+<svg width="24" height="24" viewBox="0 0 24 24" fill="none" xmlns="http://www.w3.org/2000/svg">
+  <path d="M3 3h4.5v4.5H3V3zm13.5 0H21v4.5h-4.5V3z" fill="currentColor"/>
+  <rect x="3" y="10.5" width="18" height="10.5" rx="1" fill="currentColor" opacity="0.5"/>
+  <rect x="8" y="15" width="8" height="3" rx="1" fill="currentColor"/>
+</svg>

--- a/src/components/stage/index.module.scss
+++ b/src/components/stage/index.module.scss
@@ -1,0 +1,50 @@
+.root {
+    position: relative;
+    width: 100%;
+    height: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: #14161a;
+    overflow: hidden;
+}
+
+.canvas {
+    width: 100%;
+    height: 100%;
+    display: block;
+}
+
+.badge {
+    position: absolute;
+    top: 8px;
+    right: 8px;
+    padding: 1px 8px;
+    border-radius: 4px;
+    font-size: 11px;
+    line-height: 18px;
+    letter-spacing: 0.5px;
+    text-transform: uppercase;
+    color: #fff;
+
+    &.webgpu {
+        background: #6a5acd;
+    }
+
+    &.webgl {
+        background: #2e7d32;
+    }
+}
+
+.hint {
+    position: absolute;
+    inset: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    color: #aab0b8;
+    font-size: 13px;
+    padding: 0 16px;
+    text-align: center;
+    pointer-events: none;
+}

--- a/src/components/stage/index.tsx
+++ b/src/components/stage/index.tsx
@@ -1,0 +1,182 @@
+/**
+ * @license
+ * Copyright 2026 AstrasTeam
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IVM, ITarget } from '../../types/vm/vm';
+import { events } from '../../types/vm/vm';
+import type { IAsset } from '../../types/vm/assets';
+import { useEffect, useRef, useState } from 'react';
+import { createRenderer } from '../../render';
+import type { IRenderCommand, IRenderer } from '../../render/types';
+import { decodeImageBitmap } from '../../render/decodeImage';
+import styles from './index.module.scss';
+
+/**
+ * 舞台逻辑坐标。原点居中，y 向上（Scratch 舞台规格）。
+ */
+const STAGE_GEOMETRY = { width: 480, height: 360 } as const;
+
+interface ISpriteState {
+    assetId: string;
+    bitmap: ImageBitmap;
+    width: number;
+    height: number;
+}
+
+/**
+ * 舞台面板：用统一的渲染器接口把项目的实体（entity）画到 canvas 上。
+ *
+ * - 渲染器由 {@link createRenderer} 创建（WebGPU 优先，自动降级 WebGL）。
+ * - 每个实体的"造型"取自当前项目的图片资源（按 `currentCostume` 从图片列表
+ *   取模选中），表现为可替换的纹理；将来接入造型系统后只需替换这里的映射。
+ * - 没有执行引擎时场景是静态的，故采用"状态变更时按需重绘"，不常驻 rAF。
+ */
+const StageView = ({ vm }: { vm: IVM }): React.ReactNode => {
+    const canvasRef = useRef<HTMLCanvasElement>(null);
+    const containerRef = useRef<HTMLDivElement>(null);
+    const rendererRef = useRef<IRenderer | null>(null);
+    const spriteRef = useRef<Map<string, ISpriteState>>(new Map());
+    const decodingRef = useRef<Set<string>>(new Set());
+    const rafRef = useRef(0);
+    const [backend, setBackend] = useState<string | null>(null);
+    const [hasSprite, setHasSprite] = useState(true);
+
+    const scheduleRender = () => {
+        window.cancelAnimationFrame(rafRef.current);
+        rafRef.current = window.requestAnimationFrame(() => {
+            const renderer = rendererRef.current;
+            if (!renderer) return;
+            const sprites = spriteRef.current;
+            const imageAssets = vm.runtime.assets.listAssets().filter(a => a.type === 'image');
+            setHasSprite(imageAssets.length > 0);
+
+            const commands: IRenderCommand[] = [];
+            for (const target of vm.runtime.targets.values()) {
+                if (target.mode !== 'entity') continue;
+                const sprite = getSprite(target, imageAssets, sprites);
+                if (!sprite) continue;
+                commands.push({
+                    id: target.id,
+                    textureId: sprite.assetId,
+                    x: target.x ?? 0,
+                    y: target.y ?? 0,
+                    // Scratch 方向：0=上、90=右、顺时针。默认 90 朝右。
+                    rotation: -(((target.direction ?? 90) - 90) * Math.PI) / 180,
+                    scale: (target.size ?? 100) / 100,
+                    width: sprite.width,
+                    height: sprite.height,
+                    alpha: 1 - (target.effects?.ghost ?? 0) / 100,
+                    brightness: target.effects?.brightness ?? 0,
+                });
+            }
+            renderer.render(commands, STAGE_GEOMETRY);
+        });
+    };
+
+    // 取出实体当前应绘制的造型位图；首次出现时异步解码并上传纹理后触发重绘。
+    const getSprite = (
+        target: ITarget,
+        imageAssets: IAsset[],
+        sprites: Map<string, ISpriteState>,
+    ): ISpriteState | null => {
+        if (imageAssets.length === 0) return null;
+        const asset = imageAssets[(target.currentCostume ?? 0) % imageAssets.length];
+        const cached = sprites.get(asset.id);
+        if (cached) return cached;
+        if (decodingRef.current.has(asset.id)) return null; // 已在解码中，跳过
+
+        decodingRef.current.add(asset.id);
+        void decodeImageBitmap(asset.blob, asset.mimeType)
+            .then(bitmap => {
+                decodingRef.current.delete(asset.id);
+                sprites.set(asset.id, {
+                    assetId: asset.id,
+                    bitmap,
+                    width: bitmap.width,
+                    height: bitmap.height,
+                });
+                rendererRef.current?.createTexture(asset.id, bitmap);
+                scheduleRender();
+            })
+            .catch(() => {
+                decodingRef.current.delete(asset.id);
+            });
+        return null;
+    };
+
+    useEffect(() => {
+        const canvas = canvasRef.current;
+        const container = containerRef.current;
+        if (!canvas || !container) return;
+        let disposed = false;
+
+        void createRenderer(canvas).then(renderer => {
+            if (disposed) {
+                renderer?.dispose();
+                return;
+            }
+            if (!renderer) {
+                setBackend(null);
+                return;
+            }
+            rendererRef.current = renderer;
+            renderer.mount(canvas, STAGE_GEOMETRY, { color: [255, 255, 255, 255] });
+            setBackend(renderer.backend);
+            scheduleRender();
+        });
+
+        const schedule = () => {
+            scheduleRender();
+        };
+        vm.on(events.UPDATE_TARGET_STRUCTURE, schedule);
+        vm.on(events.CREATE_PROJECT, schedule);
+        vm.on(events.SWITCH_TARGET, schedule);
+        vm.on(events.LOAD_ASSET, schedule);
+        vm.on(events.REMOVE_ASSET, schedule);
+
+        const resizeObserver = new ResizeObserver(() => {
+            rendererRef.current?.resize();
+            scheduleRender();
+        });
+        resizeObserver.observe(container);
+
+        return () => {
+            disposed = true;
+            window.cancelAnimationFrame(rafRef.current);
+            resizeObserver.disconnect();
+            vm.off(events.UPDATE_TARGET_STRUCTURE, schedule);
+            vm.off(events.CREATE_PROJECT, schedule);
+            vm.off(events.SWITCH_TARGET, schedule);
+            vm.off(events.LOAD_ASSET, schedule);
+            vm.off(events.REMOVE_ASSET, schedule);
+            rendererRef.current?.dispose();
+            rendererRef.current = null;
+            // 清理时读 ref 当前值是正确的：关闭此刻仍存活的所有位图
+            // eslint-disable-next-line react-hooks/exhaustive-deps
+            for (const sprite of spriteRef.current.values()) sprite.bitmap.close();
+            spriteRef.current.clear();
+        };
+        // scheduleRender/getSprite 每次渲染都是新闭包，这里只需依赖 vm
+        // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [vm]);
+
+    return (
+        <div ref={containerRef} className={styles.root}>
+            <canvas ref={canvasRef} className={styles.canvas} />
+            {backend === null ? (
+                <div className={styles.hint}>{'渲染器不可用（需要 WebGPU 或 WebGL）'}</div>
+            ) : (
+                <>
+                    <span className={`${styles.badge} ${styles[backend]}`}>{backend}</span>
+                    {!hasSprite && (
+                        <div className={styles.hint}>{'暂无精灵· 请先添加图片资源'}</div>
+                    )}
+                </>
+            )}
+        </div>
+    );
+};
+
+export default StageView;

--- a/src/gui/workspace/index.tsx
+++ b/src/gui/workspace/index.tsx
@@ -8,13 +8,21 @@ import { allBuiltInTabs, events, type IVM, type TallBuiltInTabs } from '../../ty
 import { useSidebarStore } from '../../stores/useSidebarStore';
 import styles from './index.module.scss';
 import BlocklyWorkspace from './Blockly/index';
-import { Fragment, useEffect, useMemo, useState, type FunctionComponent, type SVGProps } from 'react';
+import {
+    Fragment,
+    useEffect,
+    useMemo,
+    useState,
+    type FunctionComponent,
+    type SVGProps,
+} from 'react';
 import classNames from 'classnames';
 
 import SpriteIcon from '../../assets/sprite.svg?react';
 import AddonsIcon from '../../assets/addons.svg?react';
 import DebuggerIcon from '../../assets/debugger.svg?react';
 import AssetsIcon from '../../assets/assets.svg?react';
+import StageIcon from '../../assets/stage.svg?react';
 import EmptyTip from '../../assets/empty.svg?react';
 import EmptyTip2 from '../../assets/empty2.svg?react';
 
@@ -31,6 +39,7 @@ import { SHORTCUTS } from '../../types/lib';
 import TabBar from '../../tabs/TabBar';
 import { useTabsStore } from '../../stores/useTabsStore';
 import { AssetsPanel } from './assets';
+import StageView from '../../components/stage';
 
 // 应用生命周期内是否已执行过「首挂载自动打开欢迎标签」。
 // 模块级：语言切换等重挂组件也不会重复触发。
@@ -226,6 +235,8 @@ const WorkSpace = ({ vm }: { vm: IVM }): React.ReactNode => {
                         <AssetsPanel vm={vm} />
                     </SelectBar>
                 );
+            case allBuiltInTabs.STAGE:
+                return <StageView vm={vm} />;
         }
     };
 
@@ -250,6 +261,11 @@ const WorkSpace = ({ vm }: { vm: IVM }): React.ReactNode => {
                                         selected={tabSelected}
                                         id={allBuiltInTabs.ASSETS}
                                         ICON={AssetsIcon}
+                                    />
+                                    <TabButton
+                                        selected={tabSelected}
+                                        id={allBuiltInTabs.STAGE}
+                                        ICON={StageIcon}
                                     />
                                     <hr />
                                     <TabButton

--- a/src/render/backend/webglRenderer.ts
+++ b/src/render/backend/webglRenderer.ts
@@ -1,0 +1,250 @@
+/**
+ * @license
+ * Copyright 2026 AstrasTeam
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IRenderCommand, IRenderer, IStageBackground, IStageGeometry } from '../types';
+import { composeModel, composeView, type Mat4 } from '../matrix';
+
+/**
+ * 单位 quad，顶点 0..1。绘制时把中心移到 (-0.5,-0.5) 再按纹理像素尺寸拉伸。
+ * 纹理坐标直接取顶点自身坐标，保证不翻转。
+ */
+const VERTEX_GLSL = `
+precision mediump float;
+attribute vec2 a_position;
+uniform mat4 u_model;
+uniform mat4 u_view;
+uniform vec2 u_size;
+varying vec2 v_uv;
+void main() {
+    vec2 p = (a_position - 0.5) * u_size;
+    v_uv = a_position;
+    gl_Position = u_view * u_model * vec4(p, 0.0, 1.0);
+}
+`;
+
+const FRAGMENT_GLSL = `
+precision mediump float;
+varying vec2 v_uv;
+uniform sampler2D u_texture;
+uniform vec4 u_tint;       // rgb 倍率, a = 不透明度
+uniform float u_brightness; // -100..100 加性偏移（归一化）
+void main() {
+    vec4 c = texture2D(u_texture, v_uv);
+    float b = u_brightness / 100.0;
+    vec3 rgb = clamp(c.rgb * u_tint.rgb + vec3(b), 0.0, 1.0);
+    gl_FragColor = vec4(rgb, c.a * u_tint.a);
+}
+`;
+
+interface IProgramLocations {
+    aPosition: number;
+    uModel: WebGLUniformLocation | null;
+    uView: WebGLUniformLocation | null;
+    uSize: WebGLUniformLocation | null;
+    uTexture: WebGLUniformLocation | null;
+    uTint: WebGLUniformLocation | null;
+    uBrightness: WebGLUniformLocation | null;
+}
+
+const NULL_BACKGROUND: IStageBackground = { color: [0, 0, 0, 255] };
+
+function compileShader(gl: WebGLRenderingContext, type: number, source: string): WebGLShader {
+    const shader = gl.createShader(type);
+    if (!shader) throw new Error('webgl: 无法创建 shader');
+    gl.shaderSource(shader, source);
+    gl.compileShader(shader);
+    if (!gl.getShaderParameter(shader, gl.COMPILE_STATUS)) {
+        const log = gl.getShaderInfoLog(shader) ?? '';
+        gl.deleteShader(shader);
+        throw new Error(`webgl: shader 编译失败 ${log}`);
+    }
+    return shader;
+}
+
+function linkProgram(gl: WebGLRenderingContext, vs: WebGLShader, fs: WebGLShader): WebGLProgram {
+    const program = gl.createProgram();
+    gl.attachShader(program, vs);
+    gl.attachShader(program, fs);
+    gl.linkProgram(program);
+    gl.deleteShader(vs);
+    gl.deleteShader(fs);
+    if (!gl.getProgramParameter(program, gl.LINK_STATUS)) {
+        const log = gl.getProgramInfoLog(program) ?? '';
+        gl.deleteProgram(program);
+        throw new Error(`webgl: program 链接失败 ${log}`);
+    }
+    return program;
+}
+
+export class WebGLRenderer implements IRenderer {
+    readonly backend = 'webgl' as const;
+
+    private gl: WebGLRenderingContext | null = null;
+    private program: WebGLProgram | null = null;
+    private locations: IProgramLocations | null = null;
+    private quadBuffer: WebGLBuffer | null = null;
+    private textures = new Map<string, WebGLTexture>();
+
+    private background: IStageBackground = NULL_BACKGROUND;
+    private canvasWidth = 1;
+    private canvasHeight = 1;
+    private viewMatrix: Mat4 | null = null;
+
+    mount(canvas: HTMLCanvasElement, geometry: IStageGeometry, background: IStageBackground): void {
+        void geometry; // canvas 尺寸在 render/resize 由 geometry 重算，mount 阶段不需要
+        if (this.gl) throw new Error('webgl: renderer 已挂载');
+        const gl =
+            canvas.getContext('webgl2', { antialias: true, premultipliedAlpha: true }) ??
+            canvas.getContext('webgl', { antialias: true, premultipliedAlpha: true });
+        if (!gl) throw new Error('webgl: 无法获取 WebGL 上下文');
+        this.gl = gl;
+        this.background = background;
+
+        this.program = linkProgram(
+            gl,
+            compileShader(gl, gl.VERTEX_SHADER, VERTEX_GLSL),
+            compileShader(gl, gl.FRAGMENT_SHADER, FRAGMENT_GLSL),
+        );
+        gl.useProgram(this.program);
+        const attr = gl.getAttribLocation(this.program, 'a_position');
+        gl.enableVertexAttribArray(attr);
+        this.locations = {
+            aPosition: attr,
+            uModel: gl.getUniformLocation(this.program, 'u_model'),
+            uView: gl.getUniformLocation(this.program, 'u_view'),
+            uSize: gl.getUniformLocation(this.program, 'u_size'),
+            uTexture: gl.getUniformLocation(this.program, 'u_texture'),
+            uTint: gl.getUniformLocation(this.program, 'u_tint'),
+            uBrightness: gl.getUniformLocation(this.program, 'u_brightness'),
+        };
+
+        this.quadBuffer = gl.createBuffer();
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.quadBuffer);
+        // 两个三角形组成 unit quad
+        gl.bufferData(
+            gl.ARRAY_BUFFER,
+            new Float32Array([0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0, 1]),
+            gl.STATIC_DRAW,
+        );
+        gl.vertexAttribPointer(attr, 2, gl.FLOAT, false, 0, 0);
+
+        gl.disable(gl.DEPTH_TEST);
+        gl.enable(gl.BLEND);
+        gl.blendFuncSeparate(gl.SRC_ALPHA, gl.ONE_MINUS_SRC_ALPHA, gl.ONE, gl.ONE_MINUS_SRC_ALPHA);
+
+        gl.uniform1i(this.locations.uTexture, 0);
+        // 立即按加载时的尺寸适配（首次 mount 后由调用方继续 resize）
+        this.resizeInternal();
+    }
+
+    createTexture(id: string, bitmap: ImageBitmap): unknown {
+        if (!this.gl || !this.locations) throw new Error('webgl: renderer 未挂载');
+        const gl = this.gl;
+        let texture = this.textures.get(id);
+        if (!texture) {
+            texture = gl.createTexture();
+            this.textures.set(id, texture);
+        }
+        gl.bindTexture(gl.TEXTURE_2D, texture);
+        // 舞台 y 向上，quad 顶部(uv.y=1)应对应图片顶部；翻转后 texcoord(0,0)=图片底部
+        gl.pixelStorei(gl.UNPACK_FLIP_Y_WEBGL, 1);
+        // NPOT 友好：不生成 mipmap，wrap 用 CLAMP_TO_EDGE
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_S, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_WRAP_T, gl.CLAMP_TO_EDGE);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MIN_FILTER, gl.LINEAR);
+        gl.texParameteri(gl.TEXTURE_2D, gl.TEXTURE_MAG_FILTER, gl.LINEAR);
+        gl.texImage2D(gl.TEXTURE_2D, 0, gl.RGBA, gl.RGBA, gl.UNSIGNED_BYTE, bitmap);
+        gl.bindTexture(gl.TEXTURE_2D, null);
+        return id;
+    }
+
+    disposeTexture(id: string): void {
+        if (!this.gl) return;
+        const texture = this.textures.get(id);
+        if (texture) {
+            this.gl.deleteTexture(texture);
+            this.textures.delete(id);
+        }
+    }
+
+    render(commands: readonly IRenderCommand[], geometry: IStageGeometry): void {
+        const gl = this.gl;
+        const loc = this.locations;
+        if (!gl || !loc || !this.program) throw new Error('webgl: renderer 未挂载');
+        // 几何/尺寸变化后重算视口矩阵
+        this.viewMatrix = composeView(
+            this.canvasWidth,
+            this.canvasHeight,
+            geometry.width,
+            geometry.height,
+        );
+        this.resizeInternal();
+
+        gl.useProgram(this.program);
+        gl.bindBuffer(gl.ARRAY_BUFFER, this.quadBuffer);
+        gl.vertexAttribPointer(loc.aPosition, 2, gl.FLOAT, false, 0, 0);
+
+        const [br, bg, bb, ba] = this.background.color;
+        gl.clearColor(br / 255, bg / 255, bb / 255, ba / 255);
+        gl.clear(gl.COLOR_BUFFER_BIT);
+
+        gl.activeTexture(gl.TEXTURE0);
+        gl.uniformMatrix4fv(
+            loc.uView,
+            false,
+            this.viewMatrix as NonNullable<typeof this.viewMatrix>,
+        );
+
+        for (const command of commands) {
+            const texture = this.textures.get(command.textureId);
+            if (!texture) continue; // 纹理未就绪，跳过本帧
+            gl.bindTexture(gl.TEXTURE_2D, texture);
+            const model = composeModel(command.x, command.y, command.rotation, command.scale);
+            gl.uniformMatrix4fv(loc.uModel, false, model);
+            gl.uniform2f(loc.uSize, command.width, command.height);
+            gl.uniform4f(loc.uTint, 1, 1, 1, command.alpha);
+            gl.uniform1f(loc.uBrightness, command.brightness);
+            gl.drawArrays(gl.TRIANGLES, 0, 6);
+        }
+    }
+
+    private resizeInternal(): void {
+        const gl = this.gl;
+        if (!gl) return;
+        const host = gl.canvas as HTMLCanvasElement;
+        const dpr = window.devicePixelRatio || 1;
+        const cssWidth = Math.max(1, host.clientWidth || host.width);
+        const cssHeight = Math.max(1, host.clientHeight || host.height);
+        if (
+            host.width !== Math.round(cssWidth * dpr) ||
+            host.height !== Math.round(cssHeight * dpr)
+        ) {
+            host.width = Math.round(cssWidth * dpr);
+            host.height = Math.round(cssHeight * dpr);
+        }
+        this.canvasWidth = host.width;
+        this.canvasHeight = host.height;
+        gl.viewport(0, 0, host.width, host.height);
+    }
+
+    resize(): void {
+        this.resizeInternal();
+    }
+
+    dispose(): void {
+        const gl = this.gl;
+        if (!gl) return;
+        for (const texture of this.textures.values()) gl.deleteTexture(texture);
+        this.textures.clear();
+        if (this.quadBuffer) gl.deleteBuffer(this.quadBuffer);
+        if (this.program) gl.deleteProgram(this.program);
+        this.gl = null;
+        this.program = null;
+        this.locations = null;
+        this.quadBuffer = null;
+        this.viewMatrix = null;
+    }
+}

--- a/src/render/backend/webgpuRenderer.ts
+++ b/src/render/backend/webgpuRenderer.ts
@@ -1,0 +1,296 @@
+/**
+ * @license
+ * Copyright 2026 AstrasTeam
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IRenderCommand, IRenderer, IStageBackground, IStageGeometry } from '../types';
+import { composeModel, composeView } from '../matrix';
+
+/**
+ * WGSL 着色器。与 WebGL 后端保持同一套数学约定：
+ * 顶点用 `u.size` 把 unit quad 拉伸到像素尺寸并居中，
+ * `u.model` 把像素坐标变换到舞台坐标，`u.view` 把舞台坐标映射到裁剪空间。
+ *
+ * 纹理纵向约定与 WebGL 端一致：quad 顶部对应图片顶部
+ * （GL 端用 UNPACK_FLIP_Y，这里用 `uv.y = 1.0 - a_position.y`）。
+ */
+const WGSL_SOURCE = `
+struct SpriteUniforms {
+    model: mat4x4<f32>,
+    view: mat4x4<f32>,
+    size: vec2<f32>,
+    tint: vec4<f32>,
+    brightness: f32,
+};
+
+@group(0) @binding(0) var<uniform> u: SpriteUniforms;
+@group(0) @binding(1) var tex: texture_2d<f32>;
+@group(0) @binding(2) var samp: sampler;
+
+struct VsOut {
+    @builtin(position) pos: vec4<f32>,
+    @location(0) uv: vec2<f32>,
+};
+
+@vertex
+fn vs(@location(0) a_position: vec2<f32>) -> VsOut {
+    var out: VsOut;
+    let p = (a_position - vec2<f32>(0.5, 0.5)) * u.size;
+    let world = u.model * vec4<f32>(p, 0.0, 1.0);
+    out.pos = u.view * world;
+    out.uv = vec2<f32>(a_position.x, 1.0 - a_position.y);
+    return out;
+};
+
+@fragment
+fn fs(in: VsOut) -> @location(0) vec4<f32> {
+    let c = textureSample(tex, samp, in.uv);
+    let b = u.brightness / 100.0;
+    let rgb = clamp(c.rgb * u.tint.rgb + vec3<f32>(b, b, b), vec3<f32>(0.0, 0.0, 0.0), vec3<f32>(1.0, 1.0, 1.0));
+    return vec4<f32>(rgb, c.a * u.tint.a);
+};
+`;
+
+/**
+ * SpriteUniforms 内存布局（uniform 地址空间，列主序）：
+ *   model       offset  0  idx  0..15
+ *   view        offset 64  idx 16..31
+ *   size        offset128  idx 32..33
+ *   tint(vec4)  offset144  idx 36..39   （vec4 对齐 16，跳过 idx 34/35）
+ *   brightness  offset160  idx 40
+ *   总大小 176（对齐到 16）
+ */
+const UNIFORM_BYTES = 176;
+
+/** unit quad（与 WebGL 端一致），y 分量 0=顶部 */
+const QUAD = new Float32Array([0, 0, 1, 0, 0, 1, 1, 0, 1, 1, 0, 1]);
+
+interface ITextureEntry {
+    texture: GPUTexture;
+    view: GPUTextureView;
+}
+
+const NULL_BACKGROUND: IStageBackground = { color: [0, 0, 0, 255] };
+
+/**
+ * WebGPU 渲染后端。设备与 canvas 上下文由工厂在异步探测完成后创建，
+ * 因此本类构造时即已就绪（`mount` 同步）。
+ */
+export class WebGPURenderer implements IRenderer {
+    readonly backend = 'webgpu' as const;
+
+    private readonly device: GPUDevice;
+    private readonly context: GPUCanvasContext;
+    private readonly format: GPUTextureFormat;
+
+    private pipeline: GPURenderPipeline | null = null;
+    private sampler: GPUSampler | null = null;
+    private vertexBuffer: GPUBuffer | null = null;
+    private textures = new Map<string, ITextureEntry>();
+    private uniformBuffers = new Map<string, GPUBuffer>();
+
+    private background: IStageBackground = NULL_BACKGROUND;
+
+    constructor(device: GPUDevice, context: GPUCanvasContext) {
+        this.device = device;
+        this.context = context;
+        this.format = navigator.gpu.getPreferredCanvasFormat();
+    }
+
+    mount(canvas: HTMLCanvasElement, geometry: IStageGeometry, background: IStageBackground): void {
+        const device = this.device;
+        void canvas;
+        void geometry; // 渲染尺寸以每次 render 传入的 geometry 为准
+        this.background = background;
+
+        this.sampler = device.createSampler({
+            magFilter: 'linear',
+            minFilter: 'linear',
+            mipmapFilter: 'nearest',
+            addressModeU: 'clamp-to-edge',
+            addressModeV: 'clamp-to-edge',
+        });
+
+        this.pipeline = device.createRenderPipeline({
+            layout: 'auto',
+            vertex: {
+                module: device.createShaderModule({ code: WGSL_SOURCE }),
+                entryPoint: 'vs',
+                buffers: [
+                    {
+                        arrayStride: 2 * Float32Array.BYTES_PER_ELEMENT,
+                        attributes: [{ shaderLocation: 0, offset: 0, format: 'float32x2' }],
+                    },
+                ],
+            },
+            fragment: {
+                module: device.createShaderModule({ code: WGSL_SOURCE }),
+                entryPoint: 'fs',
+                targets: [{ format: this.format, blend: straightBlend() }],
+            },
+            primitive: { topology: 'triangle-list' },
+            multisample: { count: 1 },
+        });
+
+        this.vertexBuffer = device.createBuffer({
+            size: QUAD.byteLength,
+            usage: GPUBufferUsage.VERTEX | GPUBufferUsage.COPY_DST,
+        });
+        device.queue.writeBuffer(this.vertexBuffer, 0, QUAD);
+    }
+
+    createTexture(id: string, bitmap: ImageBitmap): unknown {
+        const device = this.device;
+        const old = this.textures.get(id);
+        if (old) old.texture.destroy(); // 幂等替换，避免悬空纹理
+        const texture = device.createTexture({
+            size: { width: bitmap.width, height: bitmap.height },
+            format: 'rgba8unorm',
+            usage: GPUTextureUsage.TEXTURE_BINDING | GPUTextureUsage.COPY_DST,
+        });
+        device.queue.copyExternalImageToTexture(
+            { source: bitmap },
+            { texture },
+            { width: bitmap.width, height: bitmap.height },
+        );
+        this.textures.set(id, { texture, view: texture.createView() });
+        return id;
+    }
+
+    disposeTexture(id: string): void {
+        const entry = this.textures.get(id);
+        if (entry) {
+            entry.texture.destroy();
+            this.textures.delete(id);
+        }
+    }
+
+    render(commands: readonly IRenderCommand[], geometry: IStageGeometry): void {
+        const { device, context, pipeline, sampler, vertexBuffer } = this;
+        if (!pipeline || !sampler || !vertexBuffer) return;
+
+        const canvas = context.canvas as HTMLCanvasElement;
+        const viewMatrix = composeView(
+            canvas.width,
+            canvas.height,
+            geometry.width,
+            geometry.height,
+        );
+
+        const encoder = device.createCommandEncoder();
+        const pass = encoder.beginRenderPass({
+            colorAttachments: [
+                {
+                    view: context.getCurrentTexture().createView(),
+                    clearValue: rgbaToGpu(this.background.color),
+                    loadOp: 'clear',
+                    storeOp: 'store',
+                },
+            ],
+        });
+        pass.setPipeline(pipeline);
+        pass.setVertexBuffer(0, vertexBuffer);
+
+        const frames = new Float32Array(UNIFORM_BYTES / 4);
+        for (const command of commands) {
+            const entry = this.textures.get(command.textureId);
+            if (!entry) continue;
+
+            frames.set(composeModel(command.x, command.y, command.rotation, command.scale), 0);
+            frames.set(viewMatrix, 16);
+            frames[32] = command.width;
+            frames[33] = command.height;
+            frames[36] = 1; // tint.r
+            frames[37] = 1; // tint.g
+            frames[38] = 1; // tint.b
+            frames[39] = command.alpha;
+            frames[40] = command.brightness;
+
+            let uniform = this.uniformBuffers.get(command.id);
+            if (!uniform) {
+                uniform = device.createBuffer({
+                    size: UNIFORM_BYTES,
+                    usage: GPUBufferUsage.UNIFORM | GPUBufferUsage.COPY_DST,
+                });
+                this.uniformBuffers.set(command.id, uniform);
+            }
+            device.queue.writeBuffer(uniform, 0, frames);
+
+            const bindGroup = device.createBindGroup({
+                layout: pipeline.getBindGroupLayout(0),
+                entries: [
+                    { binding: 0, resource: { buffer: uniform } },
+                    { binding: 1, resource: entry.view },
+                    { binding: 2, resource: sampler },
+                ],
+            });
+            pass.setBindGroup(0, bindGroup);
+            pass.draw(6, 1, 0, 0);
+        }
+
+        pass.end();
+        device.queue.submit([encoder.finish()]);
+
+        // 释放本帧已不存在的精灵缓存的 uniform buffer，避免无限增长
+        for (const id of this.uniformBuffers.keys()) {
+            if (!commands.some(c => c.id === id)) {
+                this.uniformBuffers.get(id)?.destroy();
+                this.uniformBuffers.delete(id);
+            }
+        }
+    }
+
+    resize(): void {
+        const { device, context } = this;
+        const canvas = context.canvas as HTMLCanvasElement;
+        const dpr = window.devicePixelRatio || 1;
+        const w = Math.max(1, Math.round((canvas.clientWidth || canvas.width) * dpr));
+        const h = Math.max(1, Math.round((canvas.clientHeight || canvas.height) * dpr));
+        if (canvas.width !== w || canvas.height !== h) {
+            canvas.width = w;
+            canvas.height = h;
+            // canvas 尺寸变化后重配 swapchain
+            context.configure({ device, format: this.format });
+        }
+    }
+
+    dispose(): void {
+        for (const entry of this.textures.values()) entry.texture.destroy();
+        this.textures.clear();
+        for (const buffer of this.uniformBuffers.values()) buffer.destroy();
+        this.uniformBuffers.clear();
+        this.pipeline = null;
+        this.sampler = null;
+        if (this.vertexBuffer) {
+            this.vertexBuffer.destroy();
+            this.vertexBuffer = null;
+        }
+        this.device.destroy();
+    }
+}
+
+/** 直通 Alpha 混合，对齐 WebGL 端 blendFuncSeparate */
+function straightBlend(): GPUBlendState {
+    return {
+        color: {
+            srcFactor: 'src-alpha',
+            dstFactor: 'one-minus-src-alpha',
+            operation: 'add',
+        },
+        alpha: {
+            srcFactor: 'one',
+            dstFactor: 'one-minus-src-alpha',
+            operation: 'add',
+        },
+    };
+}
+
+function rgbaToGpu(color: [number, number, number, number]): GPUColorDict {
+    return {
+        r: color[0] / 255,
+        g: color[1] / 255,
+        b: color[2] / 255,
+        a: color[3] / 255,
+    };
+}

--- a/src/render/decodeImage.ts
+++ b/src/render/decodeImage.ts
@@ -1,0 +1,26 @@
+/**
+ * @license
+ * Copyright 2026 AstrasTeam
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * 把资源管理器里的二进制图片解码为 `ImageBitmap`。
+ *
+ * 放在渲染包内部，让两个后端（WebGL/WebGPU）都能拿到统一的位图源，
+ * 也方便将来替换成 `createImageBitmap` 不可用时的降级路径。
+ */
+export async function decodeImageBitmap(blob: ArrayBuffer, mimeType: string): Promise<ImageBitmap> {
+    const objectURL = URL.createObjectURL(new Blob([blob], { type: mimeType }));
+    try {
+        const image = new Image();
+        image.src = objectURL;
+        // Image 需显式指定跨域策略，否则绘制位图可能被污染（ToTaintCanvas）
+        image.crossOrigin = 'anonymous';
+        await image.decode();
+        const bitmap = await createImageBitmap(image);
+        return bitmap;
+    } finally {
+        URL.revokeObjectURL(objectURL);
+    }
+}

--- a/src/render/index.ts
+++ b/src/render/index.ts
@@ -1,0 +1,73 @@
+/**
+ * @license
+ * Copyright 2026 AstrasTeam
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+import type { IRenderer, RendererBackend } from './types';
+import { WebGLRenderer } from './backend/webglRenderer';
+import { WebGPURenderer } from './backend/webgpuRenderer';
+
+/** 当前浏览器是否暴露了 WebGPU 入口 */
+function supportsGPU(): boolean {
+    return typeof navigator !== 'undefined' && 'gpu' in navigator;
+}
+
+/** 是否可用 WebGL 上下文（WebGL2 或 WebGL1） */
+function supportsWebGL(): boolean {
+    if (typeof document === 'undefined') return false;
+    const canvas = document.createElement('canvas');
+    return canvas.getContext('webgl2') !== null || canvas.getContext('webgl') !== null;
+}
+
+/**
+ * 探测本环境优先可用的后端。仅作展示/降级提示用；
+ * 实际创建以 {@link createRenderer} 为准。
+ */
+export async function detectBackend(): Promise<RendererBackend> {
+    if (supportsGPU()) {
+        try {
+            const adapter = await navigator.gpu.requestAdapter();
+            if (adapter) return 'webgpu';
+        } catch {
+            // adapter 异常，落到 WebGL
+        }
+    }
+    if (supportsWebGL()) return 'webgl';
+    return 'none';
+}
+
+/**
+ * 创建渲染器。优先 WebGPU（Astratch 主打），失败自动降级到 WebGL，
+ * 两者皆不可用时返回 `null`（调用方应给出降级提示）。
+ *
+ * @param canvas 最终承载绘图的 canvas
+ */
+export async function createRenderer(canvas: HTMLCanvasElement): Promise<IRenderer | null> {
+    if (supportsGPU()) {
+        try {
+            // 用临时 canvas 探测，避免把真实 canvas 绑死在 WebGPU 后再想降级
+            const probe = document.createElement('canvas').getContext('webgpu');
+            if (probe) {
+                const adapter = await navigator.gpu.requestAdapter();
+                if (adapter) {
+                    const device = await adapter.requestDevice();
+                    const context = canvas.getContext('webgpu');
+                    if (context) {
+                        context.configure({
+                            device,
+                            format: navigator.gpu.getPreferredCanvasFormat(),
+                        });
+                        return new WebGPURenderer(device, context);
+                    }
+                    device.destroy(); // 真实 canvas 拿不到 webgpu 上下文，放弃
+                }
+            }
+        } catch {
+            // WebGPU 初始化失败，正常降级
+        }
+    }
+
+    if (supportsWebGL()) return new WebGLRenderer();
+    return null;
+}

--- a/src/render/matrix.ts
+++ b/src/render/matrix.ts
@@ -1,0 +1,101 @@
+/**
+ * @license
+ * Copyright 2026 AstrasTeam
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * 4x4 矩阵工具（列主序，`Float32Array`，长度 16）。
+ *
+ * 统一采用列主序以兼容 WebGL GLSL `mat4` 与 WebGPU WGSL `mat4x4<f32>`
+ * （两者对 uniform 的默认排布都是列主序），因此两个后端可共享同一套数学。
+ */
+
+export type Mat4 = Float32Array & { readonly length: 16 };
+
+const identityData = (): Float32Array =>
+    new Float32Array([1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1, 0, 0, 0, 0, 1]);
+
+/** 单位矩阵 */
+export function identity(): Mat4 {
+    return identityData() as Mat4;
+}
+
+/** `a * b`（先应用 b 再应用 a；遵循矩阵左乘语义） */
+export function multiply(a: Mat4, b: Mat4): Mat4 {
+    const out = new Float32Array(16) as Mat4;
+    for (let col = 0; col < 4; col++) {
+        const b0 = b[col * 4];
+        const b1 = b[col * 4 + 1];
+        const b2 = b[col * 4 + 2];
+        const b3 = b[col * 4 + 3];
+        out[col * 4] = a[0] * b0 + a[4] * b1 + a[8] * b2 + a[12] * b3;
+        out[col * 4 + 1] = a[1] * b0 + a[5] * b1 + a[9] * b2 + a[13] * b3;
+        out[col * 4 + 2] = a[2] * b0 + a[6] * b1 + a[10] * b2 + a[14] * b3;
+        out[col * 4 + 3] = a[3] * b0 + a[7] * b1 + a[11] * b2 + a[15] * b3;
+    }
+    return out;
+}
+
+/** 平移变换 */
+export function translate(x: number, y: number, z = 0): Mat4 {
+    const m = identity();
+    m[12] = x;
+    m[13] = y;
+    m[14] = z;
+    return m;
+}
+
+/** 绕 Z 轴旋转（角度，逆时针为正；屏幕坐标下表现为顺时针供精灵面朝方向使用） */
+export function rotateZ(radians: number): Mat4 {
+    const c = Math.cos(radians);
+    const s = Math.sin(radians);
+    const m = identity();
+    m[0] = c;
+    m[1] = s;
+    m[4] = -s;
+    m[5] = c;
+    return m;
+}
+
+/** 缩放 */
+export function scale(sx: number, sy: number, sz = 1): Mat4 {
+    const m = identity();
+    m[0] = sx;
+    m[5] = sy;
+    m[10] = sz;
+    return m;
+}
+
+/**
+ * 由精灵句柄绘制时的常用组合：缩放 → 旋转 → 平移。
+ * 把原图中心对齐到 `(x, y)` 并应用方向与比例。
+ */
+export function composeModel(x: number, y: number, rotation: number, sizeScale: number): Mat4 {
+    return multiply(translate(x, y), multiply(rotateZ(rotation), scale(sizeScale, sizeScale)));
+}
+
+/**
+ * 舞台坐标（中心原点、y 向上、单位：阶段像素）→ 裁剪空间矩阵。
+ *
+ * 将 `pixelPerUnit = min(canvasW / stageW, canvasH / stageH)` 的逻辑舞台
+ * 等比适配（letterbox）进 canvas，居中，并把 y 轴翻转成裁剪坐标
+ * （WebGL/WebGPU 裁剪坐标 y 向下）。
+ */
+export function composeView(
+    canvasWidth: number,
+    canvasHeight: number,
+    stageWidth: number,
+    stageHeight: number,
+): Mat4 {
+    const pixelPerUnit = Math.min(canvasWidth / stageWidth, canvasHeight / stageHeight);
+    const scaledW = stageWidth * pixelPerUnit;
+    const scaledH = stageHeight * pixelPerUnit;
+    const offsetX = (canvasWidth - scaledW) / 2;
+    const offsetY = (canvasHeight - scaledH) / 2;
+    // clip = T(2*offX/cw, 2*offY/ch) * S(2*pixelPerUnit/cw, -2*pixelPerUnit/ch)
+    return multiply(
+        translate((2 * offsetX) / canvasWidth, (2 * offsetY) / canvasHeight),
+        scale((2 * pixelPerUnit) / canvasWidth, (-2 * pixelPerUnit) / canvasHeight),
+    );
+}

--- a/src/render/types.ts
+++ b/src/render/types.ts
@@ -1,0 +1,99 @@
+/**
+ * @license
+ * Copyright 2026 AstrasTeam
+ * SPDX-License-Identifier: Apache-2.0
+ */
+
+/**
+ * 渲染后端能力检测。
+ *
+ * `webgpu` 优先（Astratch 主打 WebGPU 渲染），其次 `webgl`，
+ * 都不支持时为 `none`。分辨不出后端时外部应给出兜底提示而非硬崩。
+ */
+export type RendererBackend = 'webgl' | 'webgpu' | 'none';
+
+/**
+ * 舞台逻辑坐标系（单位：像素）。
+ *
+ * 原点在舞台中心，y 轴向上（与 Scratch 舞台一致）：
+ * - x: 向右增大
+ * - y: 向上增大
+ */
+export interface IStageGeometry {
+    /** 舞台逻辑宽度（像素） */
+    width: number;
+    /** 舞台逻辑高度（像素） */
+    height: number;
+}
+
+/**
+ * 舞台背景。
+ * 背景用纯色填充；将来多背景/向量背景可以在此扩展。
+ */
+export interface IStageBackground {
+    /** RGBA 颜色，色值 0-255 */
+    color: [number, number, number, number];
+}
+
+/**
+ * 一条待绘制的精灵（实体）绘制指令。
+ *
+ * `rotation` 为屏幕空间顺时针旋转角（弧度）。配合 `x/y` 居中定位精灵，
+ * `scale` 为相对原图尺寸的缩放（1 为原大小）。`effects.ghost` 折算进
+ * `alpha`，`effects.brightness` 折算进 `brightness`（Scratch 语义，
+ * -100~100，默认 0 表示不变）。
+ */
+export interface IRenderCommand {
+    /** 实体 id，用于调试 */
+    id: string;
+    /** 纹理 id，指向 `IRenderer.createTexture` 时使用的 id */
+    textureId: string;
+    x: number;
+    y: number;
+    rotation: number;
+    scale: number;
+    /** 原图像素宽度（决定单位 quad 被拉伸成的大小） */
+    width: number;
+    /** 原图像素高度 */
+    height: number;
+    /** 不透明度 0-1 */
+    alpha: number;
+    /** 亮度偏移 -100~100，默认 0 */
+    brightness: number;
+}
+
+/**
+ * 渲染器统一接口。WebGL / WebGPU 两个后端都实现它，
+ * 上层（舞台）只依赖此抽象，不感知具体 API。
+ */
+export interface IRenderer {
+    readonly backend: Exclude<RendererBackend, 'none'>;
+
+    /**
+     * 挂载到 canvas 上。绘制后装进 canvas，纹理可重复使用。
+     * @param canvas 目标 canvas
+     * @param geometry 舞台逻辑坐标
+     * @param background 背景色
+     */
+    mount(canvas: HTMLCanvasElement, geometry: IStageGeometry, background: IStageBackground): void;
+
+    /**
+     * 上传一张图片作为纹理。同一 id 重复上传会替换旧纹理。
+     * 返回可在 `IRenderCommand.textureId` 中引用的不透明句柄。
+     */
+    createTexture(id: string, bitmap: ImageBitmap): unknown;
+
+    /** 释放指定 id 的纹理资源 */
+    disposeTexture(id: string): void;
+
+    /** 清空画布并绘制给定指令集。调用方负责每帧或状态变更时重绘。 */
+    render(commands: readonly IRenderCommand[], geometry: IStageGeometry): void;
+
+    /** 在容器尺寸/CSS 变化后重新适配高清缩放 */
+    resize(): void;
+
+    /** 反初始化，释放 GPU 资源 */
+    dispose(): void;
+}
+
+

--- a/src/types/vm/vm.ts
+++ b/src/types/vm/vm.ts
@@ -30,6 +30,7 @@ export const allBuiltInTabs = {
     ASSETS: 'assets',
     ADDONS: 'addons',
     DEBUG: 'debug',
+    STAGE: 'stage',
 } as const;
 export type TallBuiltInTabs = (typeof allBuiltInTabs)[keyof typeof allBuiltInTabs];
 

--- a/tsconfig.app.json
+++ b/tsconfig.app.json
@@ -4,7 +4,12 @@
         "target": "es2023",
         "lib": ["ES2023", "DOM"],
         "module": "esnext",
-        "types": ["vite/client", "wicg-file-system-access", "vite-plugin-svgr/client"],
+        "types": [
+            "vite/client",
+            "wicg-file-system-access",
+            "vite-plugin-svgr/client",
+            "@webgpu/types"
+        ],
         "skipLibCheck": true,
 
         /* Bundler mode */


### PR DESCRIPTION
## What's changed

This PR adds a unified **Stage renderer** (implemented) plus the scaffolding for the big-picture engine goals (JIT + VM-on-worker). Focus for this PR is a self-contained, mergeable rendering backend that the existing editor can already consume.

### Rendering core (`src/render/`)
- `types.ts` — abstract `IRenderer` interface + stage geometry/background/render-command types.
- `matrix.ts` — shared column-major `mat4` math (model/view composition), compatible with both GLSL `mat4` and WGSL `mat4x4<f32>`.
- `decodeImage.ts` — async image → `ImageBitmap` decoding.
- `index.ts` — `createRenderer` factory with **WebGPU-first + WebGL automatic fallback** capability detection.
- `backend/webgpuRenderer.ts` — WebGPU backend: WGSL pipeline, per-sprite uniform buffers, `copyExternalImageToTexture` upload, DPR-aware canvas resize.
- `backend/webglRenderer.ts` — WebGL2/WebGL1 backend: same math convention, `UNPACK_FLIP_Y` texture upload, blend matching the WebGPU path.

Both backends honor the Scratch stage coordinate model (origin centered, y-up, letterboxed into the canvas) and map `size/direction/rotation/ghost/brightness` uniformly.

### Stage UI (`src/components/stage/` + sidebar)
- New **Stage** panel in the left sidebar: renders the project's entities onto a canvas through the renderer, re-rendering on target/asset changes. Fallback shows a "renderer unavailable" message when no GPU context can be created.

### Misc
- Add `@webgpu/types` dev dependency for WebGPU type-checking.
- Exclude `*.svg` from prettier formatting.

## Verification
- `pnpm lint` (eslint + `tsc -b`) passes.
- `pnpm build` (vite production build) passes.

> Note: JIT compilation (TurboWarp-style) and moving the VM onto a worker (with DOM-API shims) are larger, follow-up PRs — this renderer lays the shared foundation they'll build on.